### PR TITLE
Avoid using private _Gef class, use alias from CPTData for test ID

### DIFF
--- a/packages/gef/src/evo/data_converters/gef/importer/parse_gef_files.py
+++ b/packages/gef/src/evo/data_converters/gef/importer/parse_gef_files.py
@@ -75,6 +75,10 @@ def parse_gef_files(filepaths: list[str | Path]) -> dict[str, CPTData]:
                         f"Duplicate hole_id '{hole_id}' encountered. Each hole_id (from test_id, bro_id, or filename) must be unique across all input files."
                     )
                 data[hole_id] = cpt_data
+        except FileNotFoundError:
+            raise
+        except ValueError:
+            raise
         except Exception as e:
             raise RuntimeError(f"Error processing file '{filepath}': {e}") from e
 

--- a/packages/gef/tests/test_parse_gef_files.py
+++ b/packages/gef/tests/test_parse_gef_files.py
@@ -57,19 +57,19 @@ class TestParseGefFiles:
 
     def test_file_not_found(self) -> None:
         missing_file = self.test_data_dir / "does_not_exist.gef"
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(FileNotFoundError) as exc:
             parse_gef_files([missing_file])
         assert "File not found" in str(exc.value)
 
     def test_not_cpt_type(self) -> None:
         bore_file = self.test_data_dir / "bore.gef"
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(ValueError) as exc:
             parse_gef_files([bore_file])
         assert "gef file is not a cpt" in str(exc.value)
 
     def test_unrecognized_type(self) -> None:
         bore_file = self.test_data_dir / "../../README.md"
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(ValueError) as exc:
             parse_gef_files([bore_file])
         assert "has extension '.md', expected .xml or .gef" in str(exc.value)
 
@@ -78,6 +78,6 @@ class TestParseGefFiles:
         file1 = self.test_data_dir / "cpt.gef"
         file2 = self.test_data_dir / "cpt_duplicate_test_id.gef"
 
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(ValueError) as exc:
             parse_gef_files([file1, file2])
         assert "Duplicate hole_id" in str(exc.value)


### PR DESCRIPTION
## Description

I ran into issues accessing properties of `gef` here in example notebooks and noticed that we were reading via a private class.

This uses `read_cpt` instead, and accesses "test_id" property via "alias" for GEF (ref `pygef.shim.gef_cpt_to_cpt_data`)

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] ValueError ([pygef](https://github.com/cemsbv/pygef/blob/6002e174b154a6ef7726f7a3aa467d6ada22be92/src/pygef/gef/parse_cpt.py#L27)) vs RuntimeError ([test_not_cpt_type](https://github.com/SeequentEvo/evo-data-converters/blob/b82473f6aca435340aacd722347139d3c63433d4/packages/gef/tests/test_parse_gef_files.py#L64)) from `read_cpt` if reading eg a bore file
  - tests see RuntimeError, reverted
- [x] Is `.xml` check case sensitive? yep it's lowercased
- [x] Should we be considering extension, or file contents? Perhaps contents, but for now make explicit extension
