### PR TITLE
Issue122 gef add units to measurements dataframe

### DIFF
--- a/packages/gef/pyproject.toml
+++ b/packages/gef/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 dependencies = [
     "evo-data-converters-common",
     "pandas",
+    "pint-pandas",
     "pygef[plot]",
     "pyarrow>=17.0.0",
 ]

--- a/packages/gef/src/evo/data_converters/gef/__init__.py
+++ b/packages/gef/src/evo/data_converters/gef/__init__.py
@@ -8,3 +8,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+from pint import UnitRegistry, set_application_registry
+
+# Create one registry for the GEF package
+gef_unit_registry = UnitRegistry()
+
+# Set up pint-pandas to use that registry
+set_application_registry(gef_unit_registry)

--- a/packages/gef/src/evo/data_converters/gef/converter/gef_spec.py
+++ b/packages/gef/src/evo/data_converters/gef/converter/gef_spec.py
@@ -101,3 +101,43 @@ MEASUREMENT_VAR_NAMES: dict[int, str] = {
     41: "mileage",
     42: "x_axis_north_orientation",
 }
+
+# It should be noted here that the following column names are those provided
+# by PyGef. If a column name maps to an empty string then this implies a
+# dimensionless unit. Examples of dimensionless columns would be percentage
+# values or ratios.
+MEASUREMENT_UNITS: dict[str, str] = {
+    "penetrationLength": "m",
+    "coneResistance": "MPa",
+    "localFriction": "MPa",
+    "frictionRatio": "",
+    "porePressureU1": "MPa",
+    "porePressureU2": "MPa",
+    "porePressureU3": "MPa",
+    "inclinationResultant": "degrees",
+    "inclinationNS": "degrees",
+    "inclinationEW": "degrees",
+    "depth": "m",
+    "elapsedTime": "s",
+    "correctedConeResistance": "MPa",
+    "netConeResistance": "MPa",
+    "poreRatio": "",
+    "coneResistanceRatio": "",
+    "soilDensity": "kN/m**3",
+    "porePressure": "MPa",
+    "verticalPorePressureTotal": "MPa",
+    "verticalPorePressureEffective": "MPa",
+    "inclinationX": "degrees",
+    "inclinationY": "degrees",
+    "electricalConductivity": "S/m",
+    "magneticFieldStrengthX": "nT",
+    "magneticFieldStrengthY": "nT",
+    "magneticFieldStrengthZ": "nT",
+    "magneticFieldStrengthTotal": "nT",
+    "magneticInclination": "degrees",
+    "magneticDeclination": "degrees",
+}
+
+MEASUREMENT_UNIT_CONVERSIONS: dict[str, str] = {
+    "kN/m**3": "N/m**3",
+}

--- a/uv.lock
+++ b/uv.lock
@@ -858,6 +858,7 @@ source = { editable = "packages/gef" }
 dependencies = [
     { name = "evo-data-converters-common" },
     { name = "pandas" },
+    { name = "pint-pandas" },
     { name = "pyarrow" },
     { name = "pygef", version = "0.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["plot"], marker = "python_full_version < '3.11'" },
     { name = "pygef", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["plot"], marker = "python_full_version >= '3.11'" },
@@ -873,6 +874,7 @@ dev = [
 requires-dist = [
     { name = "evo-data-converters-common", editable = "packages/common" },
     { name = "pandas" },
+    { name = "pint-pandas" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pygef", extras = ["plot"] },
 ]
@@ -1091,6 +1093,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+]
+
+[[package]]
+name = "flexcache"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
+]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
 ]
 
 [[package]]
@@ -2676,6 +2702,58 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
     { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
     { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
+]
+
+[[package]]
+name = "pint"
+version = "0.24.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "flexcache", marker = "python_full_version < '3.11'" },
+    { name = "flexparser", marker = "python_full_version < '3.11'" },
+    { name = "platformdirs", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/bb/52b15ddf7b7706ed591134a895dbf6e41c8348171fb635e655e0a4bbb0ea/pint-0.24.4.tar.gz", hash = "sha256:35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80", size = 342225, upload-time = "2024-11-07T16:29:46.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/16/bd2f5904557265882108dc2e04f18abc05ab0c2b7082ae9430091daf1d5c/Pint-0.24.4-py3-none-any.whl", hash = "sha256:aa54926c8772159fcf65f82cc0d34de6768c151b32ad1deb0331291c38fe7659", size = 302029, upload-time = "2024-11-07T16:29:43.976Z" },
+]
+
+[[package]]
+name = "pint"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "flexcache", marker = "python_full_version >= '3.11'" },
+    { name = "flexparser", marker = "python_full_version >= '3.11'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/74/bc3f671997158aef171194c3c4041e549946f4784b8690baa0626a0a164b/pint-0.25.2.tar.gz", hash = "sha256:85a45d1da8fe9c9f7477fed8aef59ad2b939af3d6611507e1a9cbdacdcd3450a", size = 254467, upload-time = "2025-11-06T22:08:09.184Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/88/550d41e81e6d43335603a960cd9c75c1d88f9cf01bc9d4ee8e86290aba7d/pint-0.25.2-py3-none-any.whl", hash = "sha256:ca35ab1d8eeeb6f7d9942b3cb5f34ca42b61cdd5fb3eae79531553dcca04dda7", size = 306762, upload-time = "2025-11-06T22:08:07.745Z" },
+]
+
+[[package]]
+name = "pint-pandas"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pandas" },
+    { name = "pint", version = "0.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pint", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/d4/1623f45236859c88d196c5f7307b675f59e17a7a7d7a70114dba4a422af2/pint_pandas-0.7.1.tar.gz", hash = "sha256:f1106215a682593f535a89696688fec88a6fac3b32ffa9fe94c307e252bcb588", size = 60693, upload-time = "2025-01-06T22:30:51.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/19/5af93cae70c2e42f3ac568906f8f3909174450bdbf4d70ec420e1daef816/Pint_Pandas-0.7.1-py3-none-any.whl", hash = "sha256:785312752eba35cbc55f4fa788c9f3d315839157d94254c5c79b91c5690ba11e", size = 28675, upload-time = "2025-01-06T22:30:49.974Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds unit mapping from GEF source files to pandas dataframes

Adds 'pint' and 'pint-pandas' to the GEF package pyproject.toml. Renamed mocked CPT data fields from 'friction' to 'localFriction' in some tests to be consistent with pygef naming.

### Notes

**Fixed with a follow up PR** 
It doesn't seem pint pandas series can be used interchangeably with pandas series, which is a bit of a hurdle, doing things like passing the series to a pyarrow array method results in an error: `ArrowTypeError: Input object was not a NumPy array`

```
pa.array(dt.get_depth_values(), type=pa.float64()),
```

We can get around this by accessing the values directly: `dt.get_depth_values().pint.magnitude` but this assumes all pandas series will be pint series.

Another option is to have a wrapper that returns the desired result- either plan pandas series, or pint annotated.

This has been solved at the AttributeFactory level in Gary's PR, but we still need something similar for things like constructing the Location->Path component in the DownholeCollectionToGeoscienceConverter

**Pint init**

I also found that you have to import something from pint pandas before it gets recognised as a valid type in pandas, so until something more elegant is found I added:

```python
from pint_pandas import PintType as _  # noqa: F401
```

to the top of `packages/gef/src/evo/data_converters/gef/converter/gef_to_downhole_collection.py`

otherwise when running a conversion from the sample notebook we get the error: `TypeError: data type 'pint[meter]' not understood`

This is a known issue with pandas extensions: https://github.com/pandas-dev/pandas/issues/29774

## Checklist

- [x] I have read the contributing guide and the code of conduct
