### PR TITLE
move column_mapping to context, isort module

### DIFF
--- a/packages/ags/pyproject.toml
+++ b/packages/ags/pyproject.toml
@@ -46,3 +46,6 @@ path = "README.md"
 # Converts relative links to absolute links in PyPI
 pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
 replacement = '[\1](https://github.com/SeequentEvo/evo-data-converters/tree/main/packages/ags/\g<2>)'
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "UP006"]

--- a/packages/ags/samples/convert-ags/convert-ags.ipynb
+++ b/packages/ags/samples/convert-ags/convert-ags.ipynb
@@ -39,6 +39,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "from evo.notebooks import ServiceManagerWidget\n",
     "\n",
     "# Credentials can be provided from .env or filled into second params below.\n",

--- a/packages/ags/src/evo/data_converters/ags/common/ags_context.py
+++ b/packages/ags/src/evo/data_converters/ags/common/ags_context.py
@@ -9,15 +9,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from functools import cached_property
 from io import StringIO
 from pathlib import Path
-import evo.logging
+
 import pandas as pd
-from .pandas_utils import coerce_to_object_int
 from pyproj import CRS
 from pyproj.exceptions import CRSError
 from python_ags4 import AGS4
-from functools import cached_property
+
+import evo.logging
+from evo.data_converters.common.objects.downhole_collection.column_mapping import ColumnMapping
+
+from .pandas_utils import coerce_to_object_int
 
 logger = evo.logging.getLogger("data_converters")
 
@@ -154,6 +158,15 @@ class AgsContext:
             if parts:
                 return " - ".join(parts)
         raise ValueError("Filename not available and PROJ_NAME/PROJ_ID not found in PROJ table")
+
+    @property
+    def column_mapping(self) -> ColumnMapping:
+        """Gets the default column mapping for downhole collections."""
+        return ColumnMapping(
+            DEPTH_COLUMNS=["SCPT_DPTH", "SCDG_DPTH"],
+            FROM_COLUMNS=["GEOL_TOP", "SCPP_TOP"],
+            TO_COLUMNS=["GEOL_BASE", "SCPP_BASE"],
+        )
 
     def parse_ags(self, filepath: Path | str | StringIO) -> None:
         """Parses an AGS file to dataframes for each table.

--- a/packages/ags/src/evo/data_converters/ags/common/pandas_utils.py
+++ b/packages/ags/src/evo/data_converters/ags/common/pandas_utils.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 
 def coerce_to_object_int(series: pd.Series) -> pd.Series:

--- a/packages/ags/src/evo/data_converters/ags/importer/__init__.py
+++ b/packages/ags/src/evo/data_converters/ags/importer/__init__.py
@@ -9,8 +9,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .ags_to_evo import convert_ags
 from .ags_to_downhole_collection import create_from_parsed_ags
+from .ags_to_evo import convert_ags
 
 __all__ = [
     "convert_ags",

--- a/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
+++ b/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
@@ -14,11 +14,7 @@ import pandas as pd
 
 import evo.logging
 from evo.data_converters.ags.common import AgsContext
-from evo.data_converters.common.objects.downhole_collection import (
-    ColumnMapping,
-    DownholeCollection,
-    HoleCollars,
-)
+from evo.data_converters.common.objects.downhole_collection import DownholeCollection, HoleCollars
 from evo.data_converters.common.objects.downhole_collection.tables import DEFAULT_AZIMUTH, DEFAULT_DIP, DistanceTable
 
 logger = evo.logging.getLogger("data_converters")
@@ -72,11 +68,7 @@ def create_from_parsed_ags(
         measurements=measurements,
         coordinate_reference_system=ags_context.coordinate_reference_system or "unspecified",
         tags=tags,
-        column_mapping=ColumnMapping(
-            DEPTH_COLUMNS=["SCPT_DPTH", "SCDG_DPTH"],
-            FROM_COLUMNS=["GEOL_TOP", "SCPP_TOP"],
-            TO_COLUMNS=["GEOL_BASE", "SCPP_BASE"],
-        ),
+        column_mapping=ags_context.column_mapping,
     )
 
     # If HORN data present, calculate dip and azimuth for the first distance table.

--- a/packages/ags/tests/importer/conftest.py
+++ b/packages/ags/tests/importer/conftest.py
@@ -11,15 +11,14 @@
 
 import tempfile
 from pathlib import Path
-import pandas as pd
 from unittest.mock import Mock
-from evo.data_converters.ags.common import AgsContext
+
+import pandas as pd
 import pytest
 
-from evo.data_converters.common import (
-    create_evo_object_service_and_data_client,
-    EvoWorkspaceMetadata,
-)
+from evo.data_converters.ags.common import AgsContext
+from evo.data_converters.common import EvoWorkspaceMetadata, create_evo_object_service_and_data_client
+from evo.data_converters.common.objects.downhole_collection.column_mapping import ColumnMapping
 
 
 @pytest.fixture(scope="session")
@@ -135,6 +134,11 @@ def mock_ags_context():
     context = Mock(spec=AgsContext)
     context.filename = "test_file.ags"
     context.coordinate_reference_system = "EPSG:4326"
+    context.column_mapping = ColumnMapping(
+        DEPTH_COLUMNS=["SCPT_DPTH", "SCDG_DPTH"],
+        FROM_COLUMNS=["GEOL_TOP", "SCPP_TOP"],
+        TO_COLUMNS=["GEOL_BASE", "SCPP_BASE"],
+    )
 
     # LOCA table
     loca_df = pd.DataFrame(

--- a/packages/ags/tests/importer/test_ags_context.py
+++ b/packages/ags/tests/importer/test_ags_context.py
@@ -9,8 +9,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pytest
 from pathlib import Path
+
+import pytest
+
 from evo.data_converters.ags.common import AgsContext, AgsFileInvalidException
 
 

--- a/packages/ags/tests/importer/test_ags_to_downhole_collection.py
+++ b/packages/ags/tests/importer/test_ags_to_downhole_collection.py
@@ -10,6 +10,7 @@
 #  limitations under the License.
 
 import pandas as pd
+
 from evo.data_converters.ags.common import AgsContext
 from evo.data_converters.ags.importer.ags_to_downhole_collection import (
     calculate_dip_and_azimuth,

--- a/packages/ags/tests/importer/test_ags_to_evo.py
+++ b/packages/ags/tests/importer/test_ags_to_evo.py
@@ -9,11 +9,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import asyncio
 from unittest.mock import Mock, patch
 
 from evo_schemas.objects import DownholeCollection_V1_3_1
 
-import asyncio
 from evo.data_converters.ags.importer.ags_to_evo import convert_ags
 from evo.objects.data import ObjectMetadata
 


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-data-converters/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

- Move column mapping to `AgsContext`, allowing the source of truth for supported column mappings and measurement tables to be in the same place
- isort the module

## Checklist

- [x] I have read the contributing guide and the code of conduct
