### PR TITLE
AGS Import: LOCA Z height

### DIFF
--- a/packages/ags/README.md
+++ b/packages/ags/README.md
@@ -59,8 +59,8 @@ This converter currently supports **Cone Penetration Test (CPT) data** and conve
 **Optional Groups (imported if present):**
 - `SCPP` - Static Cone Penetration Tests - Derived Parameters
 - `GEOL` - Field Geological Descriptions
-- `SCDG` - Static Cone Dissipation Tests - General
-  - NOTE: SCDT (Static Cone Dissipation Tests - Data) is not imported, as this is time-series data. General dissipation information is present in SCDG.
+
+Any additional groups will be discarded.
 
 ## Usage
 

--- a/packages/ags/samples/convert-ags/convert-ags.ipynb
+++ b/packages/ags/samples/convert-ags/convert-ags.ipynb
@@ -19,8 +19,6 @@
     "**Optional Groups (imported if present):**\n",
     "- `SCPP` - Static Cone Penetration Tests - Derived Parameters\n",
     "- `GEOL` - Field Geological Descriptions\n",
-    "- `SCDG` - Static Cone Dissipation Tests - General\n",
-    "  - NOTE: SCDT (Static Cone Dissipation Tests - Data) is not imported, as this is time-series data. General dissipation information is present in SCDG.\n",
     "\n",
     "The converter will transform these AGS groups into an Evo Downhole Collection object.\n",
     "\n",

--- a/packages/ags/src/evo/data_converters/ags/common/ags_context.py
+++ b/packages/ags/src/evo/data_converters/ags/common/ags_context.py
@@ -44,6 +44,8 @@ class AgsContext:
     :cvar list[str] IGNORED_RULES: AGS validation rules that are ignored during file checks.
     :cvar dict[str, str] TYPE_CATEGORY: Mapping of AGS ``TYPE`` codes to conversion categories used during
         dataframe coercion. Known categories are ``"int"``, ``"float"``, ``"datetime"``, ``timedelta``, and ``"bool"``.
+    :cvar tuple[tuple[str, tuple[str, ...]], ...] COORDINATE_COLUMN_PRIORITY: Column priority for coordinates as
+        (target_col, (source_col1, source_col2, ...)) pairs for x, y, z coordinates.
 
     :ivar dict[str, pandas.DataFrame] tables: Processed tables keyed by group
         name. Only relevant downhole collection groups are retained.
@@ -76,11 +78,11 @@ class AgsContext:
     _headings: dict[str, list[str]]
     _filename: str | None
 
-    REQUIRED_GROUPS: list[str] = ["LOCA", "SCPG", "SCPT"]
-    RETAINED_GROUPS: list[str] = ["PROJ", "UNIT", "HORN"]
-    MEASUREMENT_GROUPS: list[str] = ["SCPT", "SCPP", "GEOL", "SCDG"]
+    REQUIRED_GROUPS: tuple[str, ...] = ("LOCA", "SCPG", "SCPT")
+    RETAINED_GROUPS: tuple[str, ...] = ("PROJ", "UNIT", "HORN")
+    MEASUREMENT_GROUPS: tuple[str, ...] = ("SCPT", "SCPP", "GEOL")
 
-    IGNORED_RULES: list[str] = [
+    IGNORED_RULES: tuple[str, ...] = (
         # 2a: Each line should be terminated by CR and LF characters
         # Files from various sources use Unix line endings (LF only)
         # This is a formatting issue that doesn't affect data integrity
@@ -97,7 +99,7 @@ class AgsContext:
         # 16: Each data file shall contain the ABBR GROUP when abbreviations have been included in the data file.
         # Abbreviations are not always defined, and sometime erroneously detected.
         "AGS Format Rule 16",
-    ]
+    )
 
     # TODO: Implement proper handling for DMS (degrees/minutes/seconds)
     TYPE_CATEGORY: dict[str, str] = {
@@ -129,6 +131,12 @@ class AgsContext:
         "YN": "bool",
         # Note: ID, PA, PT, PU, RL, U, X, XN types fall back to string (default)
     }
+
+    COORDINATE_COLUMN_PRIORITY: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("x", ("LOCA_NATE", "LOCA_LOCX", "LOCA_LON")),
+        ("y", ("LOCA_NATN", "LOCA_LOCY", "LOCA_LAT")),
+        ("z", ("LOCA_GL", "LOCA_LOCZ")),
+    )
 
     def __init__(self) -> None:
         self._tables = dict()

--- a/packages/ags/src/evo/data_converters/ags/common/ags_context.py
+++ b/packages/ags/src/evo/data_converters/ags/common/ags_context.py
@@ -37,11 +37,11 @@ class AgsContext:
     In-memory context for working with AGS data. Provides parsing, validation,
     table access, and serialization utilities for AGS4 files.
 
-    :cvar list[str] REQUIRED_GROUPS: Groups required for import operations (e.g., ``LOCA``, ``SCPG``, ``SCPT``).
-    :cvar list[str] MEASUREMENT_GROUPS: Groups that contain measurement data
+    :cvar tuple[str, ...] REQUIRED_GROUPS: Groups required for import operations (e.g., ``LOCA``, ``SCPG``, ``SCPT``).
+    :cvar tuple[str, ...] MEASUREMENT_GROUPS: Groups that contain measurement data
         (e.g., ``SCPT``, ``SCPP``, ``GEOL``).
-    :cvar list[str] RETAINED_GROUPS: Other groups retained from an AGS file (e.g., ``PROJ``, ``UNIT``).
-    :cvar list[str] IGNORED_RULES: AGS validation rules that are ignored during file checks.
+    :cvar tuple[str, ...] RETAINED_GROUPS: Other groups retained from an AGS file (e.g., ``PROJ``, ``UNIT``).
+    :cvar tuple[str, ...] IGNORED_RULES: AGS validation rules that are ignored during file checks.
     :cvar dict[str, str] TYPE_CATEGORY: Mapping of AGS ``TYPE`` codes to conversion categories used during
         dataframe coercion. Known categories are ``"int"``, ``"float"``, ``"datetime"``, ``timedelta``, and ``"bool"``.
     :cvar tuple[tuple[str, tuple[str, ...]], ...] COORDINATE_COLUMN_PRIORITY: Column priority for coordinates as

--- a/packages/ags/src/evo/data_converters/ags/common/ags_context.py
+++ b/packages/ags/src/evo/data_converters/ags/common/ags_context.py
@@ -39,7 +39,7 @@ class AgsContext:
 
     :cvar list[str] REQUIRED_GROUPS: Groups required for import operations (e.g., ``LOCA``, ``SCPG``, ``SCPT``).
     :cvar list[str] MEASUREMENT_GROUPS: Groups that contain measurement data
-        (e.g., ``SCPT``, ``SCPP``, ``GEOL``, ``SCDG``).
+        (e.g., ``SCPT``, ``SCPP``, ``GEOL``).
     :cvar list[str] RETAINED_GROUPS: Other groups retained from an AGS file (e.g., ``PROJ``, ``UNIT``).
     :cvar list[str] IGNORED_RULES: AGS validation rules that are ignored during file checks.
     :cvar dict[str, str] TYPE_CATEGORY: Mapping of AGS ``TYPE`` codes to conversion categories used during
@@ -514,7 +514,7 @@ class AgsContext:
         - Metadata-like tables (e.g., PROJ, UNIT): Keep from self, warn if different
         - LOCA: Concatenate, check for duplicate LOCA_ID
         - SCPG: Concatenate, check for duplicate (LOCA_ID, SCPG_TESN) pairs
-        - Measurement tables (SCPT, SCPP, GEOL, SCDG): Concatenate all rows
+        - Measurement tables (SCPT, SCPP, GEOL): Concatenate all rows
 
         :param other: The AgsContext to merge into this one
         :param validate_compatibility: If True, raises error on incompatibility; if False, logs warnings

--- a/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
+++ b/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
@@ -33,7 +33,7 @@ def create_from_parsed_ags(
     For hole collars, we need information from the SCPG table as well as the LOCA details of the SCPG row.
     Collars are uniquely identified by LOCA_ID and SCPG_TESN together.
 
-    Fetches measurements from all relevant tables (SCPT, SCPP, GEOL, SCDG) and assigns hole_index.
+    Fetches measurements from all relevant tables (SCPT, SCPP, GEOL) and assigns hole_index.
 
     :param ags_context: The context containing the AGS file as dataframes.
     :param tags: Optional dict of tags to add to the DownholeCollection.
@@ -73,7 +73,7 @@ def create_from_parsed_ags(
         coordinate_reference_system=ags_context.coordinate_reference_system or "unspecified",
         tags=tags,
         column_mapping=ColumnMapping(
-            DEPTH_COLUMNS=["SCPT_DPTH", "SCDG_DPTH"],
+            DEPTH_COLUMNS=["SCPT_DPTH"],
             FROM_COLUMNS=["GEOL_TOP", "SCPP_TOP"],
             TO_COLUMNS=["GEOL_BASE", "SCPP_BASE"],
         ),

--- a/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
+++ b/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
@@ -127,9 +127,10 @@ def build_collars(ags_context: AgsContext) -> HoleCollars:
         assigned = False
         for source_col in source_cols:
             if source_col in collars_df.columns:
-                collars_df[target_col] = pd.to_numeric(collars_df[source_col], errors="coerce")
+                temp_col = pd.to_numeric(collars_df[source_col], errors="coerce")
                 # Check if we have any non-null values to select this column
-                if collars_df[target_col].notna().any():
+                if temp_col.notna().any():
+                    collars_df[target_col] = temp_col
                     assigned = True
                     break
 

--- a/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
+++ b/packages/ags/src/evo/data_converters/ags/importer/ags_to_downhole_collection.py
@@ -99,9 +99,6 @@ def build_collars(ags_context: AgsContext) -> HoleCollars:
 
     Collars are uniquely identified by LOCA_ID and SCPG_TESN together.
 
-    .. todo::
-       Use Z when possible (from CRS?)
-
     :param ags_context: The context containing the AGS file as dataframes.
     :return: A HoleCollars object
     """
@@ -125,9 +122,22 @@ def build_collars(ags_context: AgsContext) -> HoleCollars:
     collars_df["hole_id"] = np.where(tesn_str != "", loca_str + ":" + tesn_str, loca_str)
     collars_df["hole_index"] = range(1, len(collars_df) + 1)
 
-    # Rename coordinates and set z
-    collars_df = collars_df.rename(columns={"LOCA_NATE": "x", "LOCA_NATN": "y"})
-    collars_df["z"] = 0.0
+    # Find coordinate columns with valid data
+    for target_col, source_cols in AgsContext.COORDINATE_COLUMN_PRIORITY:
+        assigned = False
+        for source_col in source_cols:
+            if source_col in collars_df.columns:
+                collars_df[target_col] = pd.to_numeric(collars_df[source_col], errors="coerce")
+                # Check if we have any non-null values to select this column
+                if collars_df[target_col].notna().any():
+                    assigned = True
+                    break
+
+        if not assigned:
+            logger.warning(f"No valid {target_col} coordinate data found in LOCA table, defaulting to 0.0")
+            collars_df[target_col] = 0.0
+        else:
+            collars_df[target_col] = collars_df[target_col].fillna(0.0)
 
     # Ensure final_depth is float dtype even if NaN
     collars_df["final_depth"] = pd.to_numeric(collars_df["final_depth"], errors="coerce").astype(float)

--- a/packages/ags/tests/importer/conftest.py
+++ b/packages/ags/tests/importer/conftest.py
@@ -129,6 +129,18 @@ def test_timedelta_ags_path():
     return str((Path(__file__).parent / "data" / "test_timedelta.ags").resolve())
 
 
+@pytest.fixture(scope="session")
+def test_coordinate_columns_ags_path():
+    """Path to an AGS file for testing coordinate column handling."""
+    return str((Path(__file__).parent / "data" / "test_coordinate_columns.ags").resolve())
+
+
+@pytest.fixture(scope="session")
+def test_no_coordinates_ags_path():
+    """Path to an AGS file with no coordinate values."""
+    return str((Path(__file__).parent / "data" / "test_no_coordinates.ags").resolve())
+
+
 @pytest.fixture
 def mock_ags_context():
     """Create a mock AgsContext with sample data."""

--- a/packages/ags/tests/importer/conftest.py
+++ b/packages/ags/tests/importer/conftest.py
@@ -193,15 +193,6 @@ def mock_ags_context():
         }
     )
 
-    scdg_df = pd.DataFrame(
-        {
-            "LOCA_ID": ["BH01", "BH03"],
-            "SCPG_TESN": ["T01", "T01"],
-            "SCDG_DPTH": [7.5, 11.0],
-            "SCDG_T": [100, 150],
-        }
-    )
-
     def get_table_side_effect(table_name):
         if table_name == "LOCA":
             return loca_df.copy()
@@ -213,8 +204,6 @@ def mock_ags_context():
             return scpp_df.copy()
         elif table_name == "GEOL":
             return geol_df.copy()
-        elif table_name == "SCDG":
-            return scdg_df.copy()
         return pd.DataFrame()
 
     def get_tables_side_effect(groups=None):
@@ -226,8 +215,6 @@ def mock_ags_context():
                 tables.append(scpp_df.copy())
             if "GEOL" in groups:
                 tables.append(geol_df.copy())
-            if "SCDG" in groups:
-                tables.append(scdg_df.copy())
         return tables
 
     context.get_table.side_effect = get_table_side_effect

--- a/packages/ags/tests/importer/data/test_coordinate_columns.ags
+++ b/packages/ags/tests/importer/data/test_coordinate_columns.ags
@@ -1,0 +1,93 @@
+"GROUP","PROJ"
+"HEADING","PROJ_ID","PROJ_NAME","PROJ_LOC","PROJ_CLNT","PROJ_CONT","PROJ_ENG","PROJ_MEMO","FILE_FSET"
+"UNIT","","","","","","","",""
+"TYPE","ID","X","X","X","X","X","X","X"
+"DATA","TEST-COORDS","Test coordinate column handling","","","","","",""
+
+
+"GROUP","TRAN"
+"HEADING","TRAN_ISNO","TRAN_DATE","TRAN_PROD","TRAN_STAT","TRAN_DESC","TRAN_AGS","TRAN_RECV","TRAN_DLIM","TRAN_RCON","TRAN_REM","FILE_FSET"
+"UNIT","yy-mm-ddThh:hh","yyyy-mm-dd","","","","","","","","",""
+"TYPE","X","DT","X","X","X","X","X","X","X","X","X"
+"DATA","2025-11-11T11:22","2025-11-16","FGC","Final","","4.1.1","Client","|","+","",""
+
+
+"GROUP","ABBR"
+"HEADING","ABBR_HDNG","ABBR_CODE","ABBR_DESC"
+"UNIT","","",""
+"TYPE","X","X","X"
+"DATA","Abbreviation Example","ABC","Example Description"
+"DATA","HDPH_TYPE","SCP","Static cone penetrometer"
+
+
+"GROUP","TYPE"
+"HEADING","TYPE_TYPE","TYPE_DESC"
+"UNIT","",""
+"TYPE","X","X"
+"DATA","X","Text"
+"DATA","DT","Date and time in international format"
+"DATA","ID","Unique identifier"
+"DATA","0DP","Value; 0 decimal places"
+"DATA","1DP","Value; 1 decimal place"
+"DATA","2DP","Value; 2 decimal places"
+"DATA","3DP","Value; 3 decimal places"
+"DATA","4DP","Value; 4 decimal places"
+"DATA","5DP","Value; 5 decimal places"
+"DATA","DMS","Degrees, minutes and seconds"
+"DATA","PA","Pick text defined in ABBR group"
+"DATA","PT","Pick text defined in TYPE group"
+"DATA","YN","Y or N"
+
+
+"GROUP","DICT"
+"HEADING","DICT_TYPE","DICT_GRP","DICT_HDNG","DICT_STAT","DICT_DTYP","DICT_DESC","DICT_UNIT","DICT_EXMP","DICT_PGRP"
+"UNIT","","","","","","","","",""
+"TYPE","X","X","X","PT","X","X","X","X","X"
+"DATA","HEADING","SCPG","SCPG_CDIA","OTHER","2DP","Cone diameter","mm","43.7",""
+"DATA","HEADING","SCPG","SCPG_SLVL","OTHER","2DP","Sleeve length","mm","144.40",""
+"DATA","HEADING","SCPG","SCPG_SLVA","OTHER","1DP","Sleeve area","cm2","200.0",""
+"DATA","HEADING","SCPG","SCPG_ZLOC","OTHER","PA","Location zero reading","","SB",""
+
+
+"GROUP","UNIT"
+"HEADING","UNIT_UNIT","UNIT_DESC"
+"UNIT","",""
+"TYPE","ID","X"
+"DATA","U001","Example Unit"
+"DATA","yyyy-mm-dd","year month day"
+"DATA","yyyy-mm-ddThh:mm","year month day hour minute"
+
+
+"GROUP","LOCA"
+"HEADING","LOCA_ID","LOCA_TYPE","LOCA_STAT","LOCA_NATE","LOCA_NATN","LOCA_GL","LOCA_REM","LOCA_FDEP","LOCA_STAR","LOCA_PURP","LOCA_TERM","LOCA_ENDD","LOCA_LOCX","LOCA_LOCY","LOCA_LOCZ","LOCA_DATM","LOCA_LAT","LOCA_LON","LOCA_LLZ"
+"UNIT","","","","m","m","m","","m","yyyy-mm-dd","","","yyyy-mm-dd","m","m","m","","","",""
+"TYPE","ID","PA","PA","2DP","2DP","2DP","X","2DP","DT","X","X","DT","2DP","2DP","2DP","X","DMS","DMS","X"
+"DATA","BH01","SCP","Final","100.0","200.0","5.0","","10.0","2025-06-17","","","","","","","","","",""
+"DATA","BH02","SCP","Final","","","","","15.0","2025-06-17","","","","300.0","400.0","10.0","","","",""
+"DATA","BH03","SCP","Final","","","","","20.0","2025-06-17","","","","","","","","51.5074","-0.1278",""
+"DATA","BH04","SCP","Final","500.0","600.0","","","25.0","2025-06-17","","","","700.0","800.0","15.0","","","",""
+"DATA","BH05","SCP","Final","","","","","30.0","2025-06-17","","","","","","","","","",""
+
+
+"GROUP","SCPG"
+"HEADING","LOCA_ID","SCPG_TESN","SCPG_TYPE","SCPG_REF","SCPG_CSA","SCPG_RATE","SCPG_FILT","SCPG_FRIC","SCPG_WAT","SCPG_WATA","SCPG_REM","SCPG_ENV","SCPG_CONT","SCPG_METH","SCPG_CRED","SCPG_CAR","SCPG_SLAR","FILE_FSET","SCPG_CDIA","SCPG_SLVL","SCPG_SLVA","SCPG_ZLOC"
+"UNIT","","","","","cm2","mm/s","","","m","","","","","","","","","","mm","mm","cm2",""
+"TYPE","ID","X","PA","X","0DP","0DP","X","YN","2DP","X","X","X","X","X","X","2DP","5DP","X","2DP","2DP","1DP","X"
+"DATA","BH01","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH02","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH03","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH04","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH05","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+
+
+"GROUP","SCPT"
+"HEADING","LOCA_ID","SCPG_TESN","SCPT_DPTH","SCPT_RES","SCPT_FRES","SCPT_PWP2","SCPT_FRR","SCPT_QT","SCPT_QNET","SCPT_BQ","FILE_FSET"
+"UNIT","","","m","MN/m2","kN/m2","kN/m2","%","MN/m2","MN/m2","",""
+"TYPE","ID","X","2DP","3DP","3DP","1DP","3DP","3DP","3DP","4DP","X"
+"DATA","BH01","T1","1.0","0.100","","","","0.100","0.100","1.0000",""
+"DATA","BH01","T1","2.0","0.200","","","","0.200","0.200","1.0000",""
+"DATA","BH02","T1","1.5","0.150","","","","0.150","0.150","1.0000",""
+"DATA","BH03","T1","2.5","0.250","","","","0.250","0.250","1.0000",""
+"DATA","BH04","T1","3.0","0.300","","","","0.300","0.300","1.0000",""
+"DATA","BH05","T1","1.0","0.100","","","","0.100","0.100","1.0000",""
+

--- a/packages/ags/tests/importer/data/test_no_coordinates.ags
+++ b/packages/ags/tests/importer/data/test_no_coordinates.ags
@@ -1,0 +1,87 @@
+"GROUP","PROJ"
+"HEADING","PROJ_ID","PROJ_NAME","PROJ_LOC","PROJ_CLNT","PROJ_CONT","PROJ_ENG","PROJ_MEMO","FILE_FSET"
+"UNIT","","","","","","","",""
+"TYPE","ID","X","X","X","X","X","X","X"
+"DATA","TEST-NO-COORDS","Test with no coordinate values","","","","","",""
+
+
+"GROUP","TRAN"
+"HEADING","TRAN_ISNO","TRAN_DATE","TRAN_PROD","TRAN_STAT","TRAN_DESC","TRAN_AGS","TRAN_RECV","TRAN_DLIM","TRAN_RCON","TRAN_REM","FILE_FSET"
+"UNIT","yy-mm-ddThh:hh","yyyy-mm-dd","","","","","","","","",""
+"TYPE","X","DT","X","X","X","X","X","X","X","X","X"
+"DATA","2025-11-11T11:22","2025-11-16","FGC","Final","","4.1.1","Client","|","+","",""
+
+
+"GROUP","ABBR"
+"HEADING","ABBR_HDNG","ABBR_CODE","ABBR_DESC"
+"UNIT","","",""
+"TYPE","X","X","X"
+"DATA","Abbreviation Example","ABC","Example Description"
+"DATA","HDPH_TYPE","SCP","Static cone penetrometer"
+
+
+"GROUP","TYPE"
+"HEADING","TYPE_TYPE","TYPE_DESC"
+"UNIT","",""
+"TYPE","X","X"
+"DATA","X","Text"
+"DATA","DT","Date and time in international format"
+"DATA","ID","Unique identifier"
+"DATA","0DP","Value; 0 decimal places"
+"DATA","1DP","Value; 1 decimal place"
+"DATA","2DP","Value; 2 decimal places"
+"DATA","3DP","Value; 3 decimal places"
+"DATA","4DP","Value; 4 decimal places"
+"DATA","5DP","Value; 5 decimal places"
+"DATA","DMS","Degrees, minutes and seconds"
+"DATA","PA","Pick text defined in ABBR group"
+"DATA","PT","Pick text defined in TYPE group"
+"DATA","YN","Y or N"
+
+
+"GROUP","DICT"
+"HEADING","DICT_TYPE","DICT_GRP","DICT_HDNG","DICT_STAT","DICT_DTYP","DICT_DESC","DICT_UNIT","DICT_EXMP","DICT_PGRP"
+"UNIT","","","","","","","","",""
+"TYPE","X","X","X","PT","X","X","X","X","X"
+"DATA","HEADING","SCPG","SCPG_CDIA","OTHER","2DP","Cone diameter","mm","43.7",""
+"DATA","HEADING","SCPG","SCPG_SLVL","OTHER","2DP","Sleeve length","mm","144.40",""
+"DATA","HEADING","SCPG","SCPG_SLVA","OTHER","1DP","Sleeve area","cm2","200.0",""
+"DATA","HEADING","SCPG","SCPG_ZLOC","OTHER","PA","Location zero reading","","SB",""
+
+
+"GROUP","UNIT"
+"HEADING","UNIT_UNIT","UNIT_DESC"
+"UNIT","",""
+"TYPE","ID","X"
+"DATA","U001","Example Unit"
+"DATA","yyyy-mm-dd","year month day"
+"DATA","yyyy-mm-ddThh:mm","year month day hour minute"
+
+
+"GROUP","LOCA"
+"HEADING","LOCA_ID","LOCA_TYPE","LOCA_STAT","LOCA_NATE","LOCA_NATN","LOCA_GL","LOCA_REM","LOCA_FDEP","LOCA_STAR","LOCA_PURP","LOCA_TERM","LOCA_ENDD","LOCA_LOCX","LOCA_LOCY","LOCA_LOCZ","LOCA_DATM","LOCA_LAT","LOCA_LON","LOCA_LLZ"
+"UNIT","","","","m","m","m","","m","yyyy-mm-dd","","","yyyy-mm-dd","m","m","m","","","",""
+"TYPE","ID","PA","PA","2DP","2DP","2DP","X","2DP","DT","X","X","DT","2DP","2DP","2DP","X","DMS","DMS","X"
+"DATA","BH01","SCP","Final","","","","","10.0","2025-06-17","","","","","","","","","",""
+"DATA","BH02","SCP","Final","","","","","15.0","2025-06-17","","","","","","","","","",""
+"DATA","BH03","SCP","Final","","","","","20.0","2025-06-17","","","","","","","","","",""
+
+
+"GROUP","SCPG"
+"HEADING","LOCA_ID","SCPG_TESN","SCPG_TYPE","SCPG_REF","SCPG_CSA","SCPG_RATE","SCPG_FILT","SCPG_FRIC","SCPG_WAT","SCPG_WATA","SCPG_REM","SCPG_ENV","SCPG_CONT","SCPG_METH","SCPG_CRED","SCPG_CAR","SCPG_SLAR","FILE_FSET","SCPG_CDIA","SCPG_SLVL","SCPG_SLVA","SCPG_ZLOC"
+"UNIT","","","","","cm2","mm/s","","","m","","","","","","","","","","mm","mm","cm2",""
+"TYPE","ID","X","PA","X","0DP","0DP","X","YN","2DP","X","X","X","X","X","X","2DP","5DP","X","2DP","2DP","1DP","X"
+"DATA","BH01","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH02","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+"DATA","BH03","T1","PC","CP15-CF75PB20SN2 1701-2884","15","20","","N","","","","","","NEN 5140","","0.58","0.01392","","43.85","143.60","198.9","SB"
+
+
+"GROUP","SCPT"
+"HEADING","LOCA_ID","SCPG_TESN","SCPT_DPTH","SCPT_RES","SCPT_FRES","SCPT_PWP2","SCPT_FRR","SCPT_QT","SCPT_QNET","SCPT_BQ","FILE_FSET"
+"UNIT","","","m","MN/m2","kN/m2","kN/m2","%","MN/m2","MN/m2","",""
+"TYPE","ID","X","2DP","3DP","3DP","1DP","3DP","3DP","3DP","4DP","X"
+"DATA","BH01","T1","1.0","0.100","","","","0.100","0.100","1.0000",""
+"DATA","BH01","T1","2.0","0.200","","","","0.200","0.200","1.0000",""
+"DATA","BH02","T1","1.5","0.150","","","","0.150","0.150","1.0000",""
+"DATA","BH03","T1","2.5","0.250","","","","0.250","0.250","1.0000",""
+

--- a/packages/ags/tests/importer/test_ags_context.py
+++ b/packages/ags/tests/importer/test_ags_context.py
@@ -26,7 +26,7 @@ def test_ags_file_missing_cpt_groups(valid_ags_no_cpt_path):
     context = AgsContext()
     with pytest.raises(
         AgsFileInvalidException,
-        match="Missing importable groups: one or more of SCPT, SCPP, GEOL, SCDG required.",
+        match="Missing importable groups: one or more of SCPT, SCPP, GEOL required.",
     ):
         context.parse_ags(valid_ags_no_cpt_path)
 

--- a/packages/ags/tests/importer/test_ags_to_downhole_collection.py
+++ b/packages/ags/tests/importer/test_ags_to_downhole_collection.py
@@ -157,7 +157,7 @@ class TestCreateFromParsedAgsMeasurements:
         for adapter in result.measurements:
             all_columns.update(col.upper() for col in adapter.df.columns)
 
-        depth_columns = {"SCPT_DPTH", "SCPP_DPTH", "SCDG_DPTH"}
+        depth_columns = {"SCPT_DPTH", "SCPP_DPTH"}
         found_depth_columns = depth_columns & all_columns
 
         assert len(found_depth_columns) > 0, (
@@ -168,7 +168,7 @@ class TestCreateFromParsedAgsMeasurements:
         """Test that the correct number of measurement tables are created."""
         result = create_from_parsed_ags(mock_ags_context)
 
-        assert len(result.measurements) == 4
+        assert len(result.measurements) == 3  # SCPT, SCPP, GEOL
 
     def test_measurements_scpt_data(self, mock_ags_context):
         """Test that SCPT measurement data is correctly converted."""
@@ -216,22 +216,6 @@ class TestCreateFromParsedAgsMeasurements:
         assert "hole_index" in geol_df.columns
         assert len(geol_df) == 2
         assert set(geol_df["GEOL_DESC"].values) == {"Clay", "Sand"}
-
-    def test_measurements_scdg_data(self, mock_ags_context):
-        """Test that SCDG measurement data is correctly converted."""
-        result = create_from_parsed_ags(mock_ags_context)
-
-        scdg_adapter = next((a for a in result.measurements if "SCDG_DPTH" in a.df.columns), None)
-        assert scdg_adapter is not None, "SCDG measurement table not found"
-
-        scdg_df = scdg_adapter.df
-
-        assert "SCDG_DPTH" in scdg_df.columns
-        assert "SCDG_T" in scdg_df.columns
-        assert "hole_index" in scdg_df.columns
-        assert len(scdg_df) == 2
-        assert set(scdg_df["SCDG_DPTH"].values) == {7.5, 11.0}
-        assert set(scdg_df["SCDG_T"].values) == {100, 150}
 
     def test_measurements_scpt_empty_table(self, mock_ags_context):
         """Test handling when SCPT table is empty."""


### PR DESCRIPTION

## Description

- Add `AgsContext.COORDINATE_COLUMN_PRIORITY`: use the column first found with values for x, y, and z, defaulting to 0 if all columns aren't present or are nulls.
  - Column ordering isn't based on much - perhaps needs refining.
  - It may be beneficial in the future to allow user selection here.
  - Specified in `AgsContext` to keep domain knowledge together.
  -  I'd be happy to discuss these some more, as it might be reasonable to determine what to use based on the CRS - if using LOCA_GREF then it's likely we would use NATE, NATN, GL. Same if we were using LOCA_LREF then LOCX, LOCY, LOCZ. I don't know enough about their actual usage at the moment. It also might be that you'll only normally have one set of coordinates.
```
"x" => ("LOCA_NATE", "LOCA_LOCX", "LOCA_LON")
"y" => ("LOCA_NATN", "LOCA_LOCY", "LOCA_LAT")
"z" => ("LOCA_GL", "LOCA_LOCZ")
```
- Update static classvars on `AgsContext` to be immutable
- Add tests for coordinate columns, including z
- Remove SCPG group, as it's not specified in the requirements

## Checklist

- [x] I have read the contributing guide and the code of conduct
