### PR TITLE
Pass the GEF file path so it can be reported in error messages

### DIFF
--- a/packages/gef/src/evo/data_converters/gef/converter/parse_gef_files.py
+++ b/packages/gef/src/evo/data_converters/gef/converter/parse_gef_files.py
@@ -63,7 +63,7 @@ def parse_gef_file(filepath: str | Path, replace_column_voids=False) -> list[CPT
         raise RuntimeError(f"Error processing file '{filepath}': {e}") from e
 
 
-def parse_gef_files(filepaths: list[str | Path], replace_column_voids=False) -> dict[str, CPTData]:
+def parse_gef_files(filepaths: list[str | Path], replace_column_voids=False) -> dict[str, (str, CPTData)]:
     """Parse a list of GEF-CPT & GEF-XML files and return a dictionary of CPTData objects keyed by filename.
 
     Only files identified as CPT (Cone Penetration Test) are read and included.
@@ -85,7 +85,7 @@ def parse_gef_files(filepaths: list[str | Path], replace_column_voids=False) -> 
                     raise ValueError(
                         f"Duplicate ID '{cpt_id}' encountered. Each ID (from CPT 'alias' or 'bro_id') must be unique across all input files."
                     )
-                data[cpt_id] = cpt_data
+                data[cpt_id] = (filepath, cpt_data)
         except FileNotFoundError:
             raise
         except ValueError:

--- a/packages/gef/tests/test_parse_gef_files.py
+++ b/packages/gef/tests/test_parse_gef_files.py
@@ -28,7 +28,8 @@ class TestParseGefFiles:
         result = parse_gef_files([cpt_file])
         assert isinstance(result, dict)
         assert len(result) == 1
-        for v in result.values():
+        for n, v in result.values():
+            assert n == cpt_file
             assert isinstance(v, CPTData)
 
     def test_parse_multiple_valid_cpt_files(self) -> None:
@@ -41,7 +42,8 @@ class TestParseGefFiles:
         assert isinstance(result, dict)
 
         assert len(result) == 3
-        for v in result.values():
+        for i, (n, v) in enumerate(result.values()):
+            assert n == files[i]
             assert isinstance(v, CPTData)
 
     def test_parse_valid_cpt_xml_file(self) -> None:
@@ -49,7 +51,8 @@ class TestParseGefFiles:
         result = parse_gef_files([cpt_file])
         assert isinstance(result, dict)
         assert len(result) == 1
-        for v in result.values():
+        for n, v in result.values():
+            assert n == cpt_file
             assert isinstance(v, CPTData)
 
     def test_parse_cpt_xml_with_multiple_entries(self) -> None:
@@ -57,7 +60,8 @@ class TestParseGefFiles:
         result = parse_gef_files([cpt_file])
         assert isinstance(result, dict)
         assert len(result) == 2  # Expecting 2 CPT entries in the XML
-        for v in result.values():
+        for n, v in result.values():
+            assert n == cpt_file
             assert isinstance(v, CPTData)
 
     def test_file_not_found(self) -> None:
@@ -91,7 +95,7 @@ class TestParseGefFiles:
         cpt_file = self.test_data_dir / "gef-cpt/cpt_voids.gef"
         result = parse_gef_files([cpt_file], replace_column_voids=True)
         cpt_data = next(iter(result.values()))
-        assert cpt_data.data.shape == (4, 4)
+        assert cpt_data[1].data.shape == (4, 4)
 
         df = pl.DataFrame(
             {
@@ -103,13 +107,13 @@ class TestParseGefFiles:
         )
 
         for column in df.columns:
-            assert cpt_data.data[column].round(4).equals(df[column].round(4), null_equal=True)
+            assert cpt_data[1].data[column].round(4).equals(df[column].round(4), null_equal=True)
 
     def test_parse_cpt_gef_files_with_replace_column_voids_disabled(self) -> None:
         cpt_file = self.test_data_dir / "gef-cpt/cpt_voids.gef"
         result = parse_gef_files([cpt_file], replace_column_voids=False)
         cpt_data = next(iter(result.values()))
-        assert cpt_data.data.shape == (6, 4)
+        assert cpt_data[1].data.shape == (6, 4)
 
         df = pl.DataFrame(
             {
@@ -128,4 +132,4 @@ class TestParseGefFiles:
         )
 
         for column in df.columns:
-            assert cpt_data.data[column].round(4).equals(df[column].round(4), null_equal=True)
+            assert cpt_data[1].data[column].round(4).equals(df[column].round(4), null_equal=True)


### PR DESCRIPTION
Pass the GEF file path along with the CPTData so that it can be used in error reporting

Not entirely convinced that passing things around in a tuple is entirely kosher.