### PR TITLE
Pass tags to DownholeCollectionToGeoscienceObject

### DIFF
--- a/packages/common/src/evo/data_converters/common/objects/downhole_collection_to_geoscience_object.py
+++ b/packages/common/src/evo/data_converters/common/objects/downhole_collection_to_geoscience_object.py
@@ -132,6 +132,7 @@ class DownholeCollectionToGeoscienceObject:
             # Base Object
             name=self.dhc.name,
             uuid=None,
+            tags=self.dhc.tags,
             # Base Spatial Data
             bounding_box=bounding_box,
             coordinate_reference_system=coordinate_reference_system,

--- a/packages/common/tests/objects/test_downhole_collection_to_geoscience_object.py
+++ b/packages/common/tests/objects/test_downhole_collection_to_geoscience_object.py
@@ -108,6 +108,7 @@ def dhc_distance(collars_df, distance_table_mock):
 
     dhc_mock = Mock(spec=DownholeCollection)
     dhc_mock.name = "Test Distance Collection"
+    dhc_mock.tags = {"Test": "DistanceTag"}
     dhc_mock.coordinate_reference_system = 32633
     dhc_mock.collars = collars_mock
     dhc_mock.get_bounding_box.return_value = [100.0, 200.0, 500.0, 600.0, 50.0, 55.0]
@@ -124,6 +125,7 @@ def dhc_interval(collars_df, interval_table_mock, distance_table_mock):
 
     dhc_mock = Mock(spec=DownholeCollection)
     dhc_mock.name = "Test Interval Collection"
+    dhc_mock.tags = {"Test": "IntervalTag"}
     dhc_mock.coordinate_reference_system = 32633
     dhc_mock.collars = collars_mock
     dhc_mock.get_bounding_box.return_value = [100.0, 200.0, 500.0, 600.0, 50.0, 55.0]
@@ -147,6 +149,7 @@ def dhc_mixed(collars_df, distance_table_mock, interval_table_mock):
 
     dhc_mock = Mock(spec=DownholeCollection)
     dhc_mock.name = "Test Mixed Collection"
+    dhc_mock.tags = {"Test": "MixedTag"}
     dhc_mock.coordinate_reference_system = 32633
     dhc_mock.collars = collars_mock
     dhc_mock.get_bounding_box.return_value = [100.0, 200.0, 500.0, 600.0, 50.0, 55.0]
@@ -599,6 +602,7 @@ class TestEdgeCases:
 
         dhc_mock = Mock(spec=DownholeCollection)
         dhc_mock.name = "Minimal"
+        dhc_mock.tags = {"Tag": "MinimalTag"}
         dhc_mock.coordinate_reference_system = 4326
         dhc_mock.collars = collars_mock
         dhc_mock.get_bounding_box.return_value = [100.0, 100.0, 500.0, 500.0, 50.0, 50.0]
@@ -642,6 +646,7 @@ class TestEdgeCases:
 
         dhc_mock = Mock(spec=DownholeCollection)
         dhc_mock.name = "Unequal"
+        dhc_mock.tags = {"Tag": "UnequalTag"}
         dhc_mock.coordinate_reference_system = 4326
         dhc_mock.collars = collars_mock
         dhc_mock.get_bounding_box.return_value = [100.0, 300.0, 500.0, 700.0, 50.0, 60.0]


### PR DESCRIPTION
Manually cherry picked from commits:
    5fa16eacb34875a88f29455c2bd064002ef577fa
    6c416e977743feeec36502c4bb5b40462708f821

    From:   https://github.com/antbrown/evo-data-converters/
    Branch: ags-import-converter-units
    Authored By: Ant Brown
