### PR TITLE
Stricter types on AttributeConfig dataclass

### DIFF
--- a/packages/common/src/evo/data_converters/common/objects/attributes.py
+++ b/packages/common/src/evo/data_converters/common/objects/attributes.py
@@ -99,9 +99,9 @@ class AttributeConfig:
     """
 
     data_type: AttributeType
-    array_class: type
-    attribute_class: type
-    nan_class: type | None = None
+    array_class: FloatArray1 | StringArray | IntegerArray1 | DateTimeArray | BoolArray1
+    attribute_class: OneOfAttribute_Item
+    nan_class: NanContinuous | NanCategorical | None = None
 
 
 CONTINUOUS_CONFIG: AttributeConfig = AttributeConfig(


### PR DESCRIPTION
## Description

The AttributeConfig dataclass vars: array_class, attribute_class, and nan_class vars now have strict typing.

## Checklist

- [x] I have read the contributing guide and the code of conduct
