### PR TITLE
EPSG code return value now None

### DIFF
--- a/packages/gef/src/evo/data_converters/gef/converter/gef_to_downhole_collection.py
+++ b/packages/gef/src/evo/data_converters/gef/converter/gef_to_downhole_collection.py
@@ -163,7 +163,7 @@ class DownholeCollectionBuilder:
             raise ValueError(f"CPT file '{hole_id}' has invalid EPSG code in SRS name: '{srs_name}'. Error: {e}")
 
         if epsg_code == 404000:
-            epsg_code = "unspecified"
+            epsg_code = None
 
         return epsg_code
 

--- a/packages/gef/tests/test_gef_to_downhole_collection.py
+++ b/packages/gef/tests/test_gef_to_downhole_collection.py
@@ -319,13 +319,13 @@ class TestExtractEpsgCode:
 
         assert result == 4326
 
-    def test_epsg_404000_returns_unspecified(self, builder: DownholeCollectionBuilder) -> None:
+    def test_epsg_404000_returns_none(self, builder: DownholeCollectionBuilder) -> None:
         mock_cpt = Mock()
         mock_cpt.delivered_location.srs_name = "urn:ogc:def:crs:EPSG::404000"
 
         result = builder._extract_epsg_code(mock_cpt, "TEST-001")
 
-        assert result == "unspecified"
+        assert result is None
 
     def test_malformed_srs_name_raises_error(self, builder: DownholeCollectionBuilder) -> None:
         mock_cpt = Mock()


### PR DESCRIPTION
## Description
GEF extract EPSG code method now returns None instead of 'unspecified

## Checklist

- [x] I have read the contributing guide and the code of conduct
