### PR TITLE
Warn if more than 1 distance table

### DIFF
--- a/packages/common/src/evo/data_converters/common/objects/downhole_collection_to_geoscience_object.py
+++ b/packages/common/src/evo/data_converters/common/objects/downhole_collection_to_geoscience_object.py
@@ -523,6 +523,7 @@ class DownholeCollectionToGeoscienceObject:
         """
         distance_tables = self.dhc.get_measurement_tables(filter_to_table_type=[DistanceMeasurementTable])
         if len(distance_tables) >= 1 and isinstance(distance_tables[0], DistanceMeasurementTable):
+            logger.warning("Multiple distance measurement tables found. Only the first will be used.")
             return distance_tables[0]
         raise ValueError("No distance measurement tables found.")
 


### PR DESCRIPTION
## Description

Add a warning level log message if more than 1 distance table is found when generating the DownholeCollection geoscience object.

## Checklist

- [x] I have read the contributing guide and the code of conduct
